### PR TITLE
Phase 5 backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+3rdparty/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.10)
+project(html2img CXX)
+
+option(BUILD_TESTS "Build unit tests" OFF)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+execute_process(COMMAND php-config --includes OUTPUT_VARIABLE PHP_INCLUDES OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(REPLACE "-I" "" PHP_INCLUDES "${PHP_INCLUDES}")
+separate_arguments(PHP_INCLUDES)
+
+find_package(Freetype REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GD REQUIRED gdlib)
+find_package(OpenSSL REQUIRED)
+
+add_subdirectory(3rdparty/litehtml)
+set_property(TARGET litehtml PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+if(PHP_INCLUDES)
+    include_directories(${PHP_INCLUDES} 3rdparty/litehtml/include)
+    add_library(html2img SHARED src/php_html2img.cpp src/gd_canvas.cpp src/gd_container.cpp src/ft_cache.cpp src/cache.cpp)
+    target_link_libraries(html2img litehtml ${GD_LIBRARIES} Freetype::Freetype OpenSSL::Crypto)
+endif()
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_executable(gd_backend_test tests/gd_backend_test.cpp src/gd_canvas.cpp src/gd_container.cpp src/ft_cache.cpp src/cache.cpp)
+    target_link_libraries(gd_backend_test litehtml ${GD_LIBRARIES} Freetype::Freetype OpenSSL::Crypto gtest gtest_main)
+    add_test(NAME gd_backend_test COMMAND gd_backend_test)
+
+    add_test(NAME ConcurrentCacheTest
+             COMMAND php -dextension=$<TARGET_FILE:html2img> ${CMAKE_CURRENT_SOURCE_DIR}/tests/concurrent_cache.php)
+    add_test(NAME RelativePathFontTest
+             COMMAND php -dextension=$<TARGET_FILE:html2img> ${CMAKE_CURRENT_SOURCE_DIR}/tests/relative_font.php)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# html2img PHP Extension
+
+## Running the supplied sample
+
+After building the extension, you can render `demos/output_html_test.html` using a simple PHP script:
+
+```php
+<?php
+$html = file_get_contents(__DIR__ . '/demos/output_html_test.html');
+$path = html_css_to_image($html, 'png');
+echo "Image saved to: $path\n";
+```
+
+Ensure the extension is loaded:
+
+```bash
+php -dextension=html2img.so run_sample.php
+```
+
+## Building
+
+Use `bootstrap.sh` to fetch litehtml at the pinned commit and compile the extension:
+
+```bash
+./bootstrap.sh
+```
+
+The script applies `patches/litehtml-static.patch` so litehtml builds as a static library.
+For Windows cross-builds run `build-windows-mingw.sh` instead.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Clone litehtml and build the extension on Linux
+# Environment variables:
+#   PHP_PREFIX   - path prefix to phpize/php-config if not in PATH
+#   GD_LIB       - path to libgd.so (optional)
+#   FREETYPE_LIB - path to libfreetype.so (optional)
+#   PNG_LIB      - path to libpng.so (optional)
+#   JPEG_LIB     - path to libjpeg.so (optional)
+set -euo pipefail
+
+LITEHTML_DIR=3rdparty/litehtml
+if [ ! -d "$LITEHTML_DIR" ]; then
+    git clone --depth=1 --branch 35ecd69d05e72b0148204a576db62c2148084193 \
+        https://github.com/litehtml/litehtml.git "$LITEHTML_DIR"
+    (cd "$LITEHTML_DIR" && git submodule update --init --recursive)
+    patch -d "$LITEHTML_DIR" -p1 < patches/litehtml-static.patch
+fi
+
+PHPIZE=${PHP_PREFIX:+$PHP_PREFIX/bin/}phpize
+$PHPIZE
+./configure --enable-html2img
+make -j"$(nproc)"

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Build the extension using the system PHP
+# Environment variables:
+#   PHP_PREFIX   - prefix to phpize/php-config if not in PATH
+set -euo pipefail
+PHPIZE=${PHP_PREFIX:+$PHP_PREFIX/bin/}phpize
+$PHPIZE
+./configure --enable-html2img
+make -j"$(nproc)"

--- a/build-windows-mingw.sh
+++ b/build-windows-mingw.sh
@@ -1,0 +1,23 @@
+@echo off
+REM Cross-build html2img using MinGW-w64
+REM Environment variables:
+REM   PHP_PREFIX   - prefix with phpize.bat if not in PATH
+REM   GD_LIB       - path to gd.lib (optional)
+REM   FREETYPE_LIB - path to freetype.lib (optional)
+REM   PNG_LIB      - path to png.lib (optional)
+REM   JPEG_LIB     - path to jpeg.lib (optional)
+setlocal ENABLEDELAYEDEXPANSION
+set CC=x86_64-w64-mingw32-gcc
+set CXX=x86_64-w64-mingw32-g++
+if not "%PHP_PREFIX%"=="" (
+    set PHPIZE=%PHP_PREFIX%\phpize
+) else (
+    set PHPIZE=phpize
+)
+%PHPIZE%
+./configure --host=x86_64-w64-mingw32 --enable-html2img ^
+    CPPFLAGS="-static -static-libstdc++ -static-libgcc"
+if errorlevel 1 exit /b 1
+make -j%NUMBER_OF_PROCESSORS%
+if errorlevel 1 exit /b 1
+endlocal

--- a/config.m4
+++ b/config.m4
@@ -1,0 +1,12 @@
+PHP_ARG_ENABLE(html2img, whether to enable html2img, [  --enable-html2img   Enable html2img extension], no, yes)
+
+if test "$PHP_HTML2IMG" != "no"; then
+  PHP_REQUIRE_CXX()
+  PHP_ADD_INCLUDE([3rdparty/litehtml/include])
+  PHP_ADD_LIBRARY_WITH_PATH([gd], [], HTML2IMG_SHARED_LIBADD)
+  PHP_ADD_LIBRARY_WITH_PATH([freetype], [], HTML2IMG_SHARED_LIBADD)
+  PHP_ADD_LIBRARY_WITH_PATH([png], [], HTML2IMG_SHARED_LIBADD)
+  PHP_ADD_LIBRARY_WITH_PATH([jpeg], [], HTML2IMG_SHARED_LIBADD)
+  PHP_NEW_EXTENSION(html2img, src/php_html2img.cpp src/gd_canvas.cpp src/gd_container.cpp src/cache.cpp src/ft_cache.cpp, $ext_shared,, [-std=c++17])
+  PHP_SUBST(HTML2IMG_SHARED_LIBADD)
+fi

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,9 @@
+ARG_ENABLE("html2img", "html2img support", "yes")
+
+if (PHP_HTML2IMG != "no") {
+    PHP_REQUIRE_CXX()
+    ADD_SOURCES(html2img, "src\php_html2img.cpp src\gd_canvas.cpp src\gd_container.cpp src\cache.cpp src\ft_cache.cpp")
+    ADD_FLAG("CXXFLAGS_HTML2IMG", "/std:c++17")
+    PHP_ADD_INCLUDE("3rdparty\litehtml\include")
+    ADD_LIB("HTML2IMG_SHARED_LIBADD", "gd.lib freetype.lib png.lib jpeg.lib")
+}

--- a/patches/litehtml-static.patch
+++ b/patches/litehtml-static.patch
@@ -1,0 +1,5 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@
+-add_library(litehtml ${HEADER_LITEHTML} ${SOURCE_LITEHTML})
++add_library(litehtml STATIC ${HEADER_LITEHTML} ${SOURCE_LITEHTML})

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1,0 +1,75 @@
+#include "cache.hpp"
+#include <openssl/sha.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/file.h>
+#include <unistd.h>
+#include <chrono>
+#include <cstring>
+#include <fstream>
+
+std::string cache_key(const std::string &html, const std::string &format)
+{
+    std::string data = html + format + "html2img-0.1";
+    unsigned char digest[SHA_DIGEST_LENGTH];
+    SHA1(reinterpret_cast<const unsigned char*>(data.data()), data.size(), digest);
+    static const char hex[] = "0123456789abcdef";
+    std::string out; out.reserve(SHA_DIGEST_LENGTH*2);
+    for(unsigned char c: digest) {
+        out.push_back(hex[c>>4]);
+        out.push_back(hex[c&0xF]);
+    }
+    return out;
+}
+
+std::filesystem::path default_cache_dir()
+{
+#ifdef _WIN32
+    const char* tmp = getenv("TEMP");
+    if(!tmp) tmp = "C:\\Temp";
+    return std::filesystem::path(tmp) / "php-html2img-cache";
+#else
+    const char* tmp = getenv("TMPDIR");
+    if(!tmp) tmp = "/tmp";
+    return std::filesystem::path(tmp) / "php-html2img-cache";
+#endif
+}
+
+void ensure_directory(const std::filesystem::path &dir)
+{
+    std::error_code ec;
+    if(!std::filesystem::exists(dir, ec)) {
+        std::filesystem::create_directories(dir, ec);
+    }
+}
+
+FileLock::FileLock(const std::filesystem::path &file)
+{
+#ifdef _WIN32
+    handle_ = CreateFileW(std::wstring(file.wstring()).c_str(), GENERIC_READ|GENERIC_WRITE,
+                          FILE_SHARE_READ, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    OVERLAPPED ov{};
+    LockFileEx(handle_, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD, &ov);
+#else
+    fd_ = open(file.c_str(), O_RDWR | O_CREAT, 0666);
+    if(fd_ >= 0) {
+        ::flock(fd_, LOCK_EX);
+    }
+#endif
+}
+
+FileLock::~FileLock()
+{
+#ifdef _WIN32
+    if(handle_) {
+        OVERLAPPED ov{};
+        UnlockFileEx(handle_, 0, MAXDWORD, MAXDWORD, &ov);
+        CloseHandle(handle_);
+    }
+#else
+    if(fd_ >= 0) {
+        ::flock(fd_, LOCK_UN);
+        close(fd_);
+    }
+#endif
+}

--- a/src/cache.hpp
+++ b/src/cache.hpp
@@ -1,0 +1,24 @@
+#ifndef HTML2IMG_CACHE_HPP
+#define HTML2IMG_CACHE_HPP
+
+#include <string>
+#include <filesystem>
+
+std::string cache_key(const std::string &html, const std::string &format);
+
+std::filesystem::path default_cache_dir();
+void ensure_directory(const std::filesystem::path &dir);
+
+class FileLock {
+public:
+    explicit FileLock(const std::filesystem::path &file);
+    ~FileLock();
+private:
+#ifdef _WIN32
+    void *handle_{}; // HANDLE
+#else
+    int fd_{-1};
+#endif
+};
+
+#endif

--- a/src/ft_cache.cpp
+++ b/src/ft_cache.cpp
@@ -1,0 +1,28 @@
+#include "ft_cache.hpp"
+#include <stdexcept>
+
+FtCache::FtCache() {
+    if (FT_Init_FreeType(&lib_)) {
+        throw std::runtime_error("Failed to init FreeType");
+    }
+}
+
+FtCache::~FtCache() {
+    for (auto &p : cache_) {
+        FT_Done_Face(p.second);
+    }
+    FT_Done_FreeType(lib_);
+}
+
+FT_Face FtCache::load(const std::filesystem::path &path) {
+    auto it = cache_.find(path.string());
+    if (it != cache_.end()) {
+        return it->second;
+    }
+    FT_Face face;
+    if (FT_New_Face(lib_, path.string().c_str(), 0, &face)) {
+        return nullptr;
+    }
+    cache_[path.string()] = face;
+    return face;
+}

--- a/src/ft_cache.hpp
+++ b/src/ft_cache.hpp
@@ -1,0 +1,21 @@
+#ifndef HTML2IMG_FT_CACHE_HPP
+#define HTML2IMG_FT_CACHE_HPP
+
+#include <map>
+#include <string>
+#include <filesystem>
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+class FtCache {
+public:
+    FtCache();
+    ~FtCache();
+
+    FT_Face load(const std::filesystem::path &path);
+private:
+    FT_Library lib_{};
+    std::map<std::string, FT_Face> cache_;
+};
+
+#endif

--- a/src/gd_canvas.cpp
+++ b/src/gd_canvas.cpp
@@ -1,0 +1,37 @@
+#include "gd_canvas.hpp"
+#include <stdexcept>
+
+GDCanvas::GDCanvas(int w, int h, bool has_bg, unsigned int bg)
+{
+    img_ = gdImageCreateTrueColor(w, h);
+    gdImageAlphaBlending(img_, 0);
+    gdImageSaveAlpha(img_, 1);
+    if(has_bg) {
+        gdImageFilledRectangle(img_, 0,0,w,h, bg);
+    } else {
+        gdImageFilledRectangle(img_, 0,0,w,h, gdTrueColorAlpha(0,0,0,127));
+    }
+}
+
+GDCanvas::~GDCanvas()
+{
+    if(img_) gdImageDestroy(img_);
+}
+
+bool GDCanvas::export_image(const std::string &path, const std::string &format)
+{
+    FILE* f = fopen(path.c_str(), "wb");
+    if(!f) return false;
+    if(format == "png") {
+        gdImagePng(img_, f);
+    } else if(format == "gif") {
+        gdImageGif(img_, f);
+    } else if(format == "jpg" || format == "jpeg") {
+        gdImageJpeg(img_, f, 90);
+    } else {
+        fclose(f);
+        return false;
+    }
+    fclose(f);
+    return true;
+}

--- a/src/gd_canvas.hpp
+++ b/src/gd_canvas.hpp
@@ -1,0 +1,19 @@
+#ifndef HTML2IMG_GD_CANVAS_HPP
+#define HTML2IMG_GD_CANVAS_HPP
+
+#include <gd.h>
+#include <string>
+#include <vector>
+
+class GDCanvas {
+public:
+    GDCanvas(int w, int h, bool has_bg=false, unsigned int bg=0);
+    ~GDCanvas();
+
+    gdImagePtr img() const { return img_; }
+    bool export_image(const std::string &path, const std::string &format);
+private:
+    gdImagePtr img_{};
+};
+
+#endif

--- a/src/gd_container.cpp
+++ b/src/gd_container.cpp
@@ -1,0 +1,129 @@
+#include "gd_container.hpp"
+#include <gd.h>
+#include <cstring>
+#include <fstream>
+#include <filesystem>
+
+GDContainer::GDContainer(GDCanvas& canvas,
+                         const std::filesystem::path& base,
+                         const std::filesystem::path& font_dir,
+                         bool allow_remote)
+    : canvas_(canvas), base_path_(base), font_dir_(font_dir), allow_remote_(allow_remote) {}
+
+void GDContainer::register_font(const std::string& family, const std::filesystem::path& path)
+{
+    font_map_[family] = path;
+}
+
+litehtml::uint_ptr GDContainer::create_font(const litehtml::font_description& descr, const litehtml::document*, litehtml::font_metrics* fm)
+{
+    FT_Face face = nullptr;
+    auto it = font_map_.find(descr.family);
+    std::filesystem::path path;
+    if(it != font_map_.end()) {
+        path = it->second;
+    } else {
+        path = font_dir_ / descr.family;
+    }
+    if(std::filesystem::exists(path)) {
+        face = ft_.load(path);
+    }
+    if(face) {
+        FT_Set_Pixel_Sizes(face, 0, descr.size);
+        if(fm) {
+            fm->ascent = face->size->metrics.ascender >> 6;
+            fm->descent = -face->size->metrics.descender >> 6;
+            fm->height = fm->ascent + fm->descent;
+        }
+    }
+    return reinterpret_cast<litehtml::uint_ptr>(face);
+}
+
+void GDContainer::delete_font(litehtml::uint_ptr hFont)
+{
+    // fonts cached; do nothing
+}
+
+int GDContainer::text_width(const char* text, litehtml::uint_ptr hFont)
+{
+    FT_Face face = reinterpret_cast<FT_Face>(hFont);
+    if(!face) return strlen(text)*6;
+    int pen_x = 0;
+    for(const char* p=text; *p; ++p) {
+        if(FT_Load_Char(face, *p, FT_LOAD_DEFAULT)) continue;
+        pen_x += face->glyph->advance.x >> 6;
+    }
+    return pen_x;
+}
+
+void GDContainer::draw_text(litehtml::uint_ptr, const char* text, litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos)
+{
+    FT_Face face = reinterpret_cast<FT_Face>(hFont);
+    if(!face) return;
+    int pen_x = pos.x;
+    for(const char* p=text; *p; ++p) {
+        if(FT_Load_Char(face, *p, FT_LOAD_RENDER)) continue;
+        gdImagePtr bmp = gdImageCreateTrueColor(face->glyph->bitmap.width, face->glyph->bitmap.rows);
+        gdImageAlphaBlending(bmp, 0);
+        gdImageSaveAlpha(bmp, 1);
+        for(int y=0;y<face->glyph->bitmap.rows;y++) {
+            for(int x=0;x<face->glyph->bitmap.width;x++) {
+                unsigned char a = face->glyph->bitmap.buffer[y * face->glyph->bitmap.pitch + x];
+                int c = gdTrueColorAlpha(color.red, color.green, color.blue, 127 - a/2);
+                gdImageSetPixel(bmp, x, y, c);
+            }
+        }
+        gdImageCopy(canvas_.img(), bmp, pen_x + face->glyph->bitmap_left, pos.y - face->glyph->bitmap_top,
+                    0,0, face->glyph->bitmap.width, face->glyph->bitmap.rows);
+        pen_x += face->glyph->advance.x >> 6;
+        gdImageDestroy(bmp);
+    }
+}
+
+int GDContainer::pt_to_px(int pt) const
+{
+    return pt * 96 / 72;
+}
+
+int GDContainer::get_default_font_size() const
+{
+    return 16;
+}
+
+const char* GDContainer::get_default_font_name() const
+{
+    return "Arial";
+}
+
+void GDContainer::draw_solid_fill(litehtml::uint_ptr, const litehtml::background_layer& layer, const litehtml::web_color& color)
+{
+    gdImageFilledRectangle(canvas_.img(), layer.clip_box.left(), layer.clip_box.top(), layer.clip_box.right(), layer.clip_box.bottom(),
+                           gdTrueColor(color.red, color.green, color.blue));
+}
+
+void GDContainer::transform_text(litehtml::string& text, litehtml::text_transform tt)
+{
+    if(tt == litehtml::text_transform_capitalize && !text.empty()) {
+        text[0] = toupper(text[0]);
+    } else if(tt == litehtml::text_transform_uppercase) {
+        for(auto& ch : text) ch = toupper(ch);
+    } else if(tt == litehtml::text_transform_lowercase) {
+        for(auto& ch : text) ch = tolower(ch);
+    }
+}
+
+void GDContainer::get_viewport(litehtml::position& viewport) const
+{
+    viewport.x = 0;
+    viewport.y = 0;
+    viewport.width = gdImageSX(canvas_.img());
+    viewport.height = gdImageSY(canvas_.img());
+}
+
+void GDContainer::get_media_features(litehtml::media_features& media) const
+{
+    media.type = litehtml::media_type_screen;
+    media.width = gdImageSX(canvas_.img());
+    media.height = gdImageSY(canvas_.img());
+    media.color = 8;
+}

--- a/src/gd_container.hpp
+++ b/src/gd_container.hpp
@@ -1,0 +1,61 @@
+#ifndef HTML2IMG_GD_CONTAINER_HPP
+#define HTML2IMG_GD_CONTAINER_HPP
+
+#include <litehtml.h>
+#include "gd_canvas.hpp"
+#include "ft_cache.hpp"
+#include <filesystem>
+#include <unordered_map>
+
+class GDContainer : public litehtml::document_container
+{
+public:
+    GDContainer(GDCanvas& canvas,
+                const std::filesystem::path& base,
+                const std::filesystem::path& font_dir,
+                bool allow_remote);
+    void register_font(const std::string& family, const std::filesystem::path& path);
+    ~GDContainer() override = default;
+
+    litehtml::uint_ptr create_font(const litehtml::font_description& descr, const litehtml::document* doc, litehtml::font_metrics* fm) override;
+    void delete_font(litehtml::uint_ptr hFont) override;
+    int text_width(const char* text, litehtml::uint_ptr hFont) override;
+    void draw_text(litehtml::uint_ptr hdc, const char* text, litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos) override;
+    int pt_to_px(int pt) const override;
+    int get_default_font_size() const override;
+    const char* get_default_font_name() const override;
+    void draw_list_marker(litehtml::uint_ptr hdc, const litehtml::list_marker& marker) override {}
+    void load_image(const char* src, const char* baseurl, bool redraw_on_ready) override {}
+    void get_image_size(const char* src, const char* baseurl, litehtml::size& sz) override {}
+    void draw_image(litehtml::uint_ptr hdc, const litehtml::background_layer& layer, const std::string& url, const std::string& base_url) override {}
+    void draw_solid_fill(litehtml::uint_ptr hdc, const litehtml::background_layer& layer, const litehtml::web_color& color) override;
+    void draw_linear_gradient(litehtml::uint_ptr, const litehtml::background_layer&, const litehtml::background_layer::linear_gradient&) override {}
+    void draw_radial_gradient(litehtml::uint_ptr, const litehtml::background_layer&, const litehtml::background_layer::radial_gradient&) override {}
+    void draw_conic_gradient(litehtml::uint_ptr, const litehtml::background_layer&, const litehtml::background_layer::conic_gradient&) override {}
+    void draw_borders(litehtml::uint_ptr hdc, const litehtml::borders& borders, const litehtml::position& draw_pos, bool root) override {}
+
+    void set_caption(const char*) override {}
+    void set_base_url(const char* base_url) override { base_path_ = base_url ? base_url : ""; }
+    void link(const std::shared_ptr<litehtml::document>&, const litehtml::element::ptr&) override {}
+    void on_anchor_click(const char*, const litehtml::element::ptr&) override {}
+    void on_mouse_event(const litehtml::element::ptr&, litehtml::mouse_event) override {}
+    void set_cursor(const char*) override {}
+    void transform_text(litehtml::string& text, litehtml::text_transform tt) override;
+    void import_css(litehtml::string& text, const litehtml::string& url, litehtml::string& baseurl) override {}
+    void set_clip(const litehtml::position&, const litehtml::border_radiuses&) override {}
+    void del_clip() override {}
+    void get_viewport(litehtml::position& viewport) const override;
+    litehtml::element::ptr create_element(const char*, const litehtml::string_map&, const std::shared_ptr<litehtml::document>&) override { return nullptr; }
+    void get_media_features(litehtml::media_features& media) const override;
+    void get_language(litehtml::string& language, litehtml::string& culture) const override { language="en"; culture=""; }
+
+private:
+    GDCanvas& canvas_;
+    std::filesystem::path base_path_;
+    std::filesystem::path font_dir_;
+    bool allow_remote_{};
+    FtCache ft_;
+    std::unordered_map<std::string, std::filesystem::path> font_map_;
+}; 
+
+#endif

--- a/src/php_html2img.cpp
+++ b/src/php_html2img.cpp
@@ -1,0 +1,141 @@
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <filesystem>
+#include <chrono>
+#include "gd_canvas.hpp"
+#include "gd_container.hpp"
+#include "cache.hpp"
+
+extern "C" {
+    static PHP_FUNCTION(html_css_to_image);
+}
+
+ZEND_BEGIN_MODULE_GLOBALS(html2img)
+    char *cache_dir;
+    zend_long ttl;
+    char *font_path;
+    zend_bool allow_remote;
+ZEND_END_MODULE_GLOBALS(html2img)
+
+ZEND_DECLARE_MODULE_GLOBALS(html2img)
+#define HTML2IMG_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(html2img, v)
+
+static void php_html2img_init_globals(zend_html2img_globals *g)
+{
+    g->cache_dir = nullptr;
+    g->ttl = 0;
+    g->font_path = nullptr;
+    g->allow_remote = 0;
+}
+
+zend_function_entry html2img_functions[] = {
+    PHP_FE(html_css_to_image, nullptr)
+    PHP_FE_END
+};
+
+PHP_INI_BEGIN()
+    STD_PHP_INI_ENTRY("html2img.cache_dir", "", PHP_INI_ALL, OnUpdateString, cache_dir, zend_html2img_globals, html2img_globals)
+    STD_PHP_INI_ENTRY("html2img.ttl", "0", PHP_INI_ALL, OnUpdateLong, ttl, zend_html2img_globals, html2img_globals)
+    STD_PHP_INI_ENTRY("html2img.font_path", "./", PHP_INI_ALL, OnUpdateString, font_path, zend_html2img_globals, html2img_globals)
+    STD_PHP_INI_ENTRY("html2img.allow_remote", "0", PHP_INI_ALL, OnUpdateBool, allow_remote, zend_html2img_globals, html2img_globals)
+PHP_INI_END()
+
+PHP_MINIT_FUNCTION(html2img)
+{
+    ZEND_INIT_MODULE_GLOBALS(html2img, php_html2img_init_globals, nullptr);
+    REGISTER_INI_ENTRIES();
+    if(!HTML2IMG_G(cache_dir) || HTML2IMG_G(cache_dir)[0] == '\0') {
+        std::string d = default_cache_dir().string();
+        HTML2IMG_G(cache_dir) = strdup(d.c_str());
+    }
+    return SUCCESS;
+}
+
+PHP_MSHUTDOWN_FUNCTION(html2img)
+{
+    UNREGISTER_INI_ENTRIES();
+    if(HTML2IMG_G(cache_dir)) free(HTML2IMG_G(cache_dir));
+    return SUCCESS;
+}
+
+PHP_MINFO_FUNCTION(html2img)
+{
+    php_info_print_table_start();
+    php_info_print_table_header(2, "html2img support", "enabled");
+    php_info_print_table_end();
+}
+
+zend_module_entry html2img_module_entry = {
+    STANDARD_MODULE_HEADER,
+    "html2img",
+    html2img_functions,
+    PHP_MINIT(html2img),
+    PHP_MSHUTDOWN(html2img),
+    nullptr,
+    nullptr,
+    PHP_MINFO(html2img),
+    PHP_VERSION,
+    STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_HTML2IMG
+extern "C" ZEND_GET_MODULE(html2img)
+#endif
+
+PHP_FUNCTION(html_css_to_image)
+{
+    zend_string *html;
+    zend_string *format = nullptr;
+
+    ZEND_PARSE_PARAMETERS_START(1, 2)
+        Z_PARAM_STR(html)
+        Z_PARAM_OPTIONAL
+        Z_PARAM_STR(format)
+    ZEND_PARSE_PARAMETERS_END();
+
+    std::string fmt = format ? ZSTR_VAL(format) : "png";
+    std::string html_str(ZSTR_VAL(html), ZSTR_LEN(html));
+
+    std::string key = cache_key(html_str, fmt);
+    std::filesystem::path dir = HTML2IMG_G(cache_dir);
+    ensure_directory(dir);
+    std::filesystem::path file = dir / (key + "." + fmt);
+
+    auto now = std::chrono::system_clock::now();
+    if(std::filesystem::exists(file)) {
+        if(HTML2IMG_G(ttl) == 0) {
+            RETURN_STRING(file.string().c_str());
+        } else {
+            auto ft = std::filesystem::last_write_time(file);
+            auto exp = ft + std::chrono::seconds(HTML2IMG_G(ttl));
+            if(exp > std::filesystem::file_time_type::clock::now()) {
+                RETURN_STRING(file.string().c_str());
+            }
+        }
+    }
+
+    FileLock lock(dir / (key + ".lock"));
+    if(std::filesystem::exists(file)) {
+        RETURN_STRING(file.string().c_str());
+    }
+
+    GDCanvas dummy(1,1,false);
+    std::filesystem::path cwd = std::filesystem::current_path();
+    GDContainer cont(dummy, cwd, HTML2IMG_G(font_path), HTML2IMG_G(allow_remote));
+
+    auto doc = litehtml::document::createFromString(html_str.c_str(), &cont);
+    doc->render(800);
+    int w = doc->width();
+    int h = doc->height();
+
+    GDCanvas canvas(w? w:1, h? h:1, false);
+    GDContainer cont2(canvas, cwd, HTML2IMG_G(font_path), HTML2IMG_G(allow_remote));
+    doc = litehtml::document::createFromString(html_str.c_str(), &cont2);
+    doc->render(w);
+    litehtml::position clip(0,0,w,h);
+    doc->draw(0,0,0,&clip);
+    canvas.export_image(file.string(), fmt);
+
+    RETURN_STRING(file.string().c_str());
+}

--- a/tests/concurrent_cache.php
+++ b/tests/concurrent_cache.php
@@ -1,0 +1,26 @@
+<?php
+$ext = getenv('HTML2IMG_EXT') ?: __DIR__.'/../html2img.so';
+if (!extension_loaded('html2img')) {
+    dl($ext);
+}
+$html = '<div style="width:4px;height:4px;background:#000"></div>';
+$format = 'png';
+$paths = [];
+$func = function() use ($html, $format, &$paths) {
+    $paths[] = html_css_to_image($html, $format);
+};
+$pid = pcntl_fork();
+if ($pid == 0) {
+    $func();
+    exit(0);
+} else {
+    $func();
+    pcntl_wait($status);
+}
+if ($paths[0] !== $paths[1]) { echo "FAIL path mismatch\n"; exit(1); }
+$mtime1 = filemtime($paths[0]);
+sleep(1);
+$mtime2 = filemtime($paths[1]);
+if ($mtime1 != $mtime2) { echo "FAIL multiple renders\n"; exit(1); }
+echo "OK\n";
+?>

--- a/tests/gd_backend_test.cpp
+++ b/tests/gd_backend_test.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include "../src/gd_canvas.hpp"
+#include "../src/gd_container.hpp"
+#include <litehtml.h>
+
+TEST(TransparentSurfaceTest, AlphaZeroWhenNoBackground)
+{
+    GDCanvas canvas(10,10,false);
+    GDContainer cont(canvas, ".", "./", false);
+    auto doc = litehtml::document::createFromString("<div style=\"width:10px;height:10px\"></div>", &cont);
+    doc->render(10);
+    litehtml::position clip(0,0,10,10);
+    doc->draw(0,0,0,&clip);
+    int c = gdImageGetTrueColorPixel(canvas.img(),0,0);
+    EXPECT_EQ(gdTrueColorGetAlpha(c), 127);
+}
+
+TEST(OpaqueSurfaceTest, BackgroundFill)
+{
+    const char* html = "<div style=\"background:#7B7F8D;width:10px;height:10px\"></div>";
+    GDCanvas canvas(10,10,true, gdTrueColor(0x7B,0x7F,0x8D));
+    GDContainer cont(canvas, ".", "./", false);
+    auto doc = litehtml::document::createFromString(html, &cont);
+    doc->render(10);
+    litehtml::position clip(0,0,10,10);
+    doc->draw(0,0,0,&clip);
+    int c = gdImageGetTrueColorPixel(canvas.img(),0,0);
+    EXPECT_EQ(gdTrueColorGetAlpha(c), 0);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/relative_font.php
+++ b/tests/relative_font.php
@@ -1,0 +1,10 @@
+<?php
+$ext = getenv('HTML2IMG_EXT') ?: __DIR__.'/../html2img.so';
+if (!extension_loaded('html2img')) dl($ext);
+$fontPath = 'php-8.2.29-src/ext/gd/tests/Rochester-Regular.otf';
+$html = "<style>@font-face{font-family:'Custom';src:url('{$fontPath}');}</style><div style='font:20px Custom;'>A</div>";
+$path = html_css_to_image($html, 'png');
+$md5 = md5_file($path);
+file_put_contents(__DIR__.'/relative_font.md5', $md5);
+echo "$md5\n";
+?>


### PR DESCRIPTION
## Summary
- finalize build scripts for linux and windows cross compile
- update bootstrap script with litehtml patch and compile steps
- link against system image libraries in build configs
- document build instructions and patch usage in README
- remove bundled test font and point test to a PHP-provided font

## Testing
- `./bootstrap.sh` *(fails: Remote branch not found)*
- `cmake -DBUILD_TESTS=ON -S . -B build` *(fails: litehtml directory missing)*
- `php -dextension=build/libhtml2img.so -r '$html="<div style="background:#f00;width:4px;height:4px"></div>"; echo html_css_to_image($html,"gif"), PHP_EOL;'` *(fails: unable to load extension)*


------
https://chatgpt.com/codex/tasks/task_e_6885541552c48330a29a4cd55615dab3