### PR TITLE
Fix windows config script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,13 +20,13 @@ set_property(TARGET litehtml PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(PHP_INCLUDES)
     include_directories(${PHP_INCLUDES} 3rdparty/litehtml/include)
-    add_library(html2img SHARED src/php_html2img.cpp src/gd_canvas.cpp src/gd_container.cpp src/ft_cache.cpp src/cache.cpp)
+    add_library(html2img SHARED php_html2img.cpp gd_canvas.cpp gd_container.cpp ft_cache.cpp cache.cpp)
     target_link_libraries(html2img litehtml ${GD_LIBRARIES} Freetype::Freetype OpenSSL::Crypto)
 endif()
 
 if(BUILD_TESTS)
     enable_testing()
-    add_executable(gd_backend_test tests/gd_backend_test.cpp src/gd_canvas.cpp src/gd_container.cpp src/ft_cache.cpp src/cache.cpp)
+    add_executable(gd_backend_test tests/gd_backend_test.cpp gd_canvas.cpp gd_container.cpp ft_cache.cpp cache.cpp)
     target_link_libraries(gd_backend_test litehtml ${GD_LIBRARIES} Freetype::Freetype OpenSSL::Crypto gtest gtest_main)
     add_test(NAME gd_backend_test COMMAND gd_backend_test)
 

--- a/config.m4
+++ b/config.m4
@@ -7,6 +7,6 @@ if test "$PHP_HTML2IMG" != "no"; then
   PHP_ADD_LIBRARY_WITH_PATH([freetype], [], HTML2IMG_SHARED_LIBADD)
   PHP_ADD_LIBRARY_WITH_PATH([png], [], HTML2IMG_SHARED_LIBADD)
   PHP_ADD_LIBRARY_WITH_PATH([jpeg], [], HTML2IMG_SHARED_LIBADD)
-  PHP_NEW_EXTENSION(html2img, src/php_html2img.cpp src/gd_canvas.cpp src/gd_container.cpp src/cache.cpp src/ft_cache.cpp, $ext_shared,, [-std=c++17])
+  PHP_NEW_EXTENSION(html2img, php_html2img.cpp gd_canvas.cpp gd_container.cpp cache.cpp ft_cache.cpp, $ext_shared,, [-std=c++17])
   PHP_SUBST(HTML2IMG_SHARED_LIBADD)
 fi

--- a/config.w32
+++ b/config.w32
@@ -1,9 +1,9 @@
-ARG_ENABLE("html2img", "html2img support", "yes")
+ARG_ENABLE("html2img", "html2img support", "yes");
 
 if (PHP_HTML2IMG != "no") {
-    PHP_REQUIRE_CXX()
-    ADD_SOURCES(html2img, "src\php_html2img.cpp src\gd_canvas.cpp src\gd_container.cpp src\cache.cpp src\ft_cache.cpp")
-    ADD_FLAG("CXXFLAGS_HTML2IMG", "/std:c++17")
-    PHP_ADD_INCLUDE("3rdparty\litehtml\include")
-    ADD_LIB("HTML2IMG_SHARED_LIBADD", "gd.lib freetype.lib png.lib jpeg.lib")
+    PHP_REQUIRE_CXX();
+    ADD_SOURCES(html2img, "php_html2img.cpp gd_canvas.cpp gd_container.cpp cache.cpp ft_cache.cpp");
+    ADD_FLAG("CXXFLAGS_HTML2IMG", "/std:c++17");
+    PHP_ADD_INCLUDE("3rdparty\litehtml\include");
+    ADD_LIB("HTML2IMG_SHARED_LIBADD", "gd.lib freetype.lib png.lib jpeg.lib");
 }

--- a/php-8.2.29-devel-vs16-x64/src/config.m4
+++ b/php-8.2.29-devel-vs16-x64/src/config.m4
@@ -7,6 +7,6 @@ if test "$PHP_HTML2IMG" != "no"; then
   PHP_ADD_LIBRARY_WITH_PATH([freetype], [], HTML2IMG_SHARED_LIBADD)
   PHP_ADD_LIBRARY_WITH_PATH([png], [], HTML2IMG_SHARED_LIBADD)
   PHP_ADD_LIBRARY_WITH_PATH([jpeg], [], HTML2IMG_SHARED_LIBADD)
-  PHP_NEW_EXTENSION(html2img, src/php_html2img.cpp src/gd_canvas.cpp src/gd_container.cpp src/cache.cpp src/ft_cache.cpp, $ext_shared,, [-std=c++17])
+  PHP_NEW_EXTENSION(html2img, php_html2img.cpp gd_canvas.cpp gd_container.cpp cache.cpp ft_cache.cpp, $ext_shared,, [-std=c++17])
   PHP_SUBST(HTML2IMG_SHARED_LIBADD)
 fi

--- a/php-8.2.29-devel-vs16-x64/src/config.w32
+++ b/php-8.2.29-devel-vs16-x64/src/config.w32
@@ -1,9 +1,9 @@
-ARG_ENABLE("html2img", "html2img support", "yes")
+ARG_ENABLE("html2img", "html2img support", "yes");
 
 if (PHP_HTML2IMG != "no") {
-    PHP_REQUIRE_CXX()
-    ADD_SOURCES(html2img, "src\php_html2img.cpp src\gd_canvas.cpp src\gd_container.cpp src\cache.cpp src\ft_cache.cpp")
-    ADD_FLAG("CXXFLAGS_HTML2IMG", "/std:c++17")
-    PHP_ADD_INCLUDE("3rdparty\litehtml\include")
-    ADD_LIB("HTML2IMG_SHARED_LIBADD", "gd.lib freetype.lib png.lib jpeg.lib")
+    PHP_REQUIRE_CXX();
+    ADD_SOURCES(html2img, "php_html2img.cpp gd_canvas.cpp gd_container.cpp cache.cpp ft_cache.cpp");
+    ADD_FLAG("CXXFLAGS_HTML2IMG", "/std:c++17");
+    PHP_ADD_INCLUDE("3rdparty\litehtml\include");
+    ADD_LIB("HTML2IMG_SHARED_LIBADD", "gd.lib freetype.lib png.lib jpeg.lib");
 }


### PR DESCRIPTION
## Summary
- ensure Windows `config.w32` defines ARG_ENABLE with semicolons
- fix source paths for both Windows and Unix builds
- update CMakeLists to match the new paths

## Testing
- `./build-linux.sh` *(fails: 3rdparty/litehtml missing)*

------
https://chatgpt.com/codex/tasks/task_e_68857c6eb10c8330b438f9536c8df5d0