### PR TITLE
Fix font file lookup in html2img

### DIFF
--- a/php-8.4.10-devel-vs17-x64/src/gd_container.cpp
+++ b/php-8.4.10-devel-vs17-x64/src/gd_container.cpp
@@ -28,6 +28,17 @@ litehtml::uint_ptr GDContainer::create_font(const litehtml::font_description& de
         path = it->second;
     } else {
         path = font_dir_ / descr.family;
+        if(!std::filesystem::exists(path)) {
+            static const char* exts[] = {".ttf", ".otf", ".ttc"};
+            for(const char* ext : exts) {
+                auto candidate = path;
+                candidate += ext;
+                if(std::filesystem::exists(candidate)) {
+                    path = candidate;
+                    break;
+                }
+            }
+        }
     }
     if(std::filesystem::exists(path)) {
         face = ft_.load(path);


### PR DESCRIPTION
## Summary
- resolve font loading when family name lacks extension

## Testing
- `php -v`

------
https://chatgpt.com/codex/tasks/task_e_6885bd226cb0833089b1f9cbbc1bb4b2