### PR TITLE
Fix asset path handling for html2img extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ The script applies `patches/litehtml-static.patch` so litehtml builds as a stati
 For Windows cross-builds run `build-windows-mingw.sh` or build with Visual Studio using `build-windows-vs17.bat`.
 You can also open `html2img.sln` in Visual Studio 2022 and build the `Release|x64` configuration.
 
+
+## Asset path resolution
+
+Relative URLs for fonts and images are resolved relative to the PHP script calling `html_css_to_image()`. When referencing assets with `file://` URIs, the extension strips the scheme and handles Windows drive letters so both CLI and Apache SAPI locate the files correctly.

--- a/php-8.4.10-devel-vs17-x64/src/gd_container.cpp
+++ b/php-8.4.10-devel-vs17-x64/src/gd_container.cpp
@@ -147,7 +147,13 @@ void GDContainer::get_media_features(litehtml::media_features& media) const
 std::filesystem::path GDContainer::resolve_path(const std::string& src, const std::string& base)
 {
     if(src.rfind("file://", 0) == 0) {
-        return std::filesystem::path(src.substr(7));
+        std::string p = src.substr(7);
+        if(!p.empty() && p[0]=='/') {
+#ifdef _WIN32
+            if(p.size() >= 3 && p[2]==':') p.erase(0,1);
+#endif
+        }
+        return std::filesystem::path(p);
     }
     if(src.find("://") != std::string::npos) {
         return allow_remote_ ? std::filesystem::path(src) : std::filesystem::path();


### PR DESCRIPTION
## Summary
- ensure `file://` URIs strip the extra slash on Windows
- resolve assets relative to the executing script
- use helper to strip `file://` scheme when registering fonts
- document asset path resolution for CLI and Apache

## Testing
- `./build-linux.sh` *(fails: `Cannot find config.m4`)*
- `cmake ..` in `build/` *(fails: missing `3rdparty/litehtml`)*

------
https://chatgpt.com/codex/tasks/task_e_6885cf552780833085e64fab1d74014a