### PR TITLE
Switch rendering backend to Cairo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,23 +12,37 @@ separate_arguments(PHP_INCLUDES)
 
 find_package(Freetype REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(GD REQUIRED gdlib)
+pkg_check_modules(CAIRO REQUIRED cairo)
+pkg_check_modules(PNG REQUIRED libpng)
+pkg_check_modules(JPEG REQUIRED libjpeg)
+pkg_check_modules(GIF REQUIRED libgif)
 find_package(OpenSSL REQUIRED)
 
 add_subdirectory(3rdparty/litehtml)
 set_property(TARGET litehtml PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(PHP_INCLUDES)
-    include_directories(${PHP_INCLUDES} 3rdparty/litehtml/include)
-    add_library(html2img SHARED php_html2img.cpp gd_canvas.cpp gd_container.cpp ft_cache.cpp cache.cpp path_utils.cpp)
-    target_link_libraries(html2img litehtml ${GD_LIBRARIES} Freetype::Freetype OpenSSL::Crypto)
+    include_directories(${PHP_INCLUDES} 3rdparty/litehtml/include ${CAIRO_INCLUDE_DIRS} ${FREETYPE_INCLUDE_DIRS} ${PNG_INCLUDE_DIRS} ${JPEG_INCLUDE_DIRS} ${GIF_INCLUDE_DIRS})
+    add_library(html2img SHARED
+        php-8.4.10-devel-vs17-x64/src/php_html2img.cpp
+        php-8.4.10-devel-vs17-x64/src/cairo_canvas.cpp
+        php-8.4.10-devel-vs17-x64/src/cairo_container.cpp
+        php-8.4.10-devel-vs17-x64/src/ft_cache.cpp
+        php-8.4.10-devel-vs17-x64/src/cache.cpp
+        php-8.4.10-devel-vs17-x64/src/path_utils.cpp)
+    target_link_libraries(html2img litehtml ${CAIRO_LIBRARIES} ${PNG_LIBRARIES} ${JPEG_LIBRARIES} ${GIF_LIBRARIES} Freetype::Freetype OpenSSL::Crypto)
 endif()
 
 if(BUILD_TESTS)
     enable_testing()
-    add_executable(gd_backend_test tests/gd_backend_test.cpp gd_canvas.cpp gd_container.cpp ft_cache.cpp cache.cpp path_utils.cpp)
-    target_link_libraries(gd_backend_test litehtml ${GD_LIBRARIES} Freetype::Freetype OpenSSL::Crypto gtest gtest_main)
-    add_test(NAME gd_backend_test COMMAND gd_backend_test)
+    add_executable(cairo_backend_test tests/cairo_backend_test.cpp
+        php-8.4.10-devel-vs17-x64/src/cairo_canvas.cpp
+        php-8.4.10-devel-vs17-x64/src/cairo_container.cpp
+        php-8.4.10-devel-vs17-x64/src/ft_cache.cpp
+        php-8.4.10-devel-vs17-x64/src/cache.cpp
+        php-8.4.10-devel-vs17-x64/src/path_utils.cpp)
+    target_link_libraries(cairo_backend_test litehtml ${CAIRO_LIBRARIES} ${PNG_LIBRARIES} ${JPEG_LIBRARIES} ${GIF_LIBRARIES} Freetype::Freetype OpenSSL::Crypto gtest gtest_main)
+    add_test(NAME cairo_backend_test COMMAND cairo_backend_test)
 
     add_test(NAME ConcurrentCacheTest
              COMMAND php -dextension=$<TARGET_FILE:html2img> ${CMAKE_CURRENT_SOURCE_DIR}/tests/concurrent_cache.php)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,16 +2,16 @@
 # Clone litehtml and build the extension on Linux
 # Environment variables:
 #   PHP_PREFIX   - path prefix to phpize/php-config if not in PATH
-#   GD_LIB       - path to libgd.so (optional)
+#   CAIRO_LIB    - path to libcairo.so (optional)
 #   FREETYPE_LIB - path to libfreetype.so (optional)
 #   PNG_LIB      - path to libpng.so (optional)
 #   JPEG_LIB     - path to libjpeg.so (optional)
+#   GIF_LIB      - path to libgif.so (optional)
 set -euo pipefail
 
 LITEHTML_DIR=3rdparty/litehtml
 if [ ! -d "$LITEHTML_DIR" ]; then
-    git clone --depth=1 --branch 35ecd69d05e72b0148204a576db62c2148084193 \
-        https://github.com/litehtml/litehtml.git "$LITEHTML_DIR"
+    git clone --depth=1 https://github.com/litehtml/litehtml.git "$LITEHTML_DIR"
     (cd "$LITEHTML_DIR" && git submodule update --init --recursive)
     patch -d "$LITEHTML_DIR" -p1 < patches/litehtml-static.patch
 fi

--- a/php-8.4.10-devel-vs17-x64/src/cairo_canvas.cpp
+++ b/php-8.4.10-devel-vs17-x64/src/cairo_canvas.cpp
@@ -1,0 +1,91 @@
+#include "cairo_canvas.hpp"
+#include <gif_lib.h>
+#include <jpeglib.h>
+#include <vector>
+#include <cstring>
+
+CairoCanvas::CairoCanvas(int w, int h, bool has_bg, unsigned int bg)
+{
+    surface_ = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+    cr_ = cairo_create(surface_);
+    double a = has_bg ? 1.0 : 0.0;
+    cairo_set_source_rgba(cr_,
+                          ((bg >> 16) & 0xFF) / 255.0,
+                          ((bg >> 8) & 0xFF) / 255.0,
+                          (bg & 0xFF) / 255.0,
+                          a);
+    cairo_paint(cr_);
+}
+
+CairoCanvas::~CairoCanvas()
+{
+    if(cr_) cairo_destroy(cr_);
+    if(surface_) cairo_surface_destroy(surface_);
+}
+
+bool CairoCanvas::export_image(const std::string& path, const std::string& format)
+{
+    if(format == "png") {
+        return cairo_surface_write_to_png(surface_, path.c_str()) == CAIRO_STATUS_SUCCESS;
+    } else if(format == "jpg" || format == "jpeg") {
+        int width = cairo_image_surface_get_width(surface_);
+        int height = cairo_image_surface_get_height(surface_);
+        unsigned char* data = cairo_image_surface_get_data(surface_);
+        FILE* f = fopen(path.c_str(), "wb");
+        if(!f) return false;
+        jpeg_compress_struct cinfo{};
+        jpeg_error_mgr jerr{};
+        cinfo.err = jpeg_std_error(&jerr);
+        jpeg_create_compress(&cinfo);
+        jpeg_stdio_dest(&cinfo, f);
+        cinfo.image_width = width;
+        cinfo.image_height = height;
+        cinfo.input_components = 3;
+        cinfo.in_color_space = JCS_RGB;
+        jpeg_set_defaults(&cinfo);
+        jpeg_set_quality(&cinfo, 90, TRUE);
+        jpeg_start_compress(&cinfo, TRUE);
+        std::vector<unsigned char> row(width*3);
+        while(cinfo.next_scanline < cinfo.image_height) {
+            unsigned char* src = data + cinfo.next_scanline * cairo_image_surface_get_stride(surface_);
+            for(int x=0;x<width;x++) {
+                row[x*3+0] = src[x*4+2];
+                row[x*3+1] = src[x*4+1];
+                row[x*3+2] = src[x*4+0];
+            }
+            unsigned char* rowptr = row.data();
+            jpeg_write_scanlines(&cinfo, &rowptr, 1);
+        }
+        jpeg_finish_compress(&cinfo);
+        jpeg_destroy_compress(&cinfo);
+        fclose(f);
+        return true;
+    } else if(format == "gif") {
+        int width = cairo_image_surface_get_width(surface_);
+        int height = cairo_image_surface_get_height(surface_);
+        unsigned char* data = cairo_image_surface_get_data(surface_);
+        int err = 0;
+        GifFileType* gif = EGifOpenFileName(path.c_str(), false, &err);
+        if(!gif) return false;
+        EGifPutScreenDesc(gif, width, height, 8, 0, nullptr);
+        std::vector<GifByteType> img(width*height*4);
+        for(int y=0;y<height;y++) {
+            unsigned char* src = data + y*cairo_image_surface_get_stride(surface_);
+            for(int x=0;x<width;x++) {
+                img[(y*width+x)*4+0] = src[x*4+2];
+                img[(y*width+x)*4+1] = src[x*4+1];
+                img[(y*width+x)*4+2] = src[x*4+0];
+                img[(y*width+x)*4+3] = 255 - src[x*4+3];
+            }
+        }
+        EGifPutImageDesc(gif, 0,0,width,height,false,nullptr);
+        for(int y=0;y<height;y++) {
+            GifByteType* row = &img[y*width*4];
+            if(EGifPutLine(gif, row, width*4) == GIF_ERROR) { err=1; break; }
+        }
+        EGifCloseFile(gif, &err);
+        return err==0;
+    }
+    return false;
+}
+

--- a/php-8.4.10-devel-vs17-x64/src/cairo_canvas.hpp
+++ b/php-8.4.10-devel-vs17-x64/src/cairo_canvas.hpp
@@ -1,0 +1,20 @@
+#ifndef HTML2IMG_CAIRO_CANVAS_HPP
+#define HTML2IMG_CAIRO_CANVAS_HPP
+
+#include <cairo.h>
+#include <string>
+
+class CairoCanvas {
+public:
+    CairoCanvas(int w, int h, bool has_bg = false, unsigned int bg = 0);
+    ~CairoCanvas();
+
+    cairo_surface_t* surface() const { return surface_; }
+    cairo_t* cr() const { return cr_; }
+    bool export_image(const std::string& path, const std::string& format);
+private:
+    cairo_surface_t* surface_{nullptr};
+    cairo_t* cr_{nullptr};
+};
+
+#endif

--- a/php-8.4.10-devel-vs17-x64/src/cairo_container.cpp
+++ b/php-8.4.10-devel-vs17-x64/src/cairo_container.cpp
@@ -1,0 +1,201 @@
+#define LITEHTML_STD_VARIANT 1
+#define LITEHTML_STD_OPTIONAL 1
+#define LITEHTML_STD_FILESYSTEM 1
+
+#include "cairo_container.hpp"
+#include <cairo-ft.h>
+#include <cstring>
+#include <fstream>
+#include <filesystem>
+#include "path_utils.hpp"
+
+CairoContainer::CairoContainer(CairoCanvas& canvas,
+                               const std::filesystem::path& base,
+                               const std::filesystem::path& font_dir,
+                               bool allow_remote)
+    : canvas_(canvas), base_path_(base), font_dir_(font_dir), allow_remote_(allow_remote) {}
+
+void CairoContainer::register_font(const std::string& family, const std::filesystem::path& path)
+{
+    font_map_[family] = path;
+}
+
+litehtml::uint_ptr CairoContainer::create_font(const litehtml::font_description& descr, const litehtml::document*, litehtml::font_metrics* fm)
+{
+    FT_Face face = nullptr;
+    auto it = font_map_.find(descr.family);
+    std::filesystem::path path;
+    if(it != font_map_.end()) {
+        path = it->second;
+    } else {
+        path = font_dir_ / descr.family;
+        if(!std::filesystem::exists(path)) {
+            static const char* exts[] = {".ttf", ".otf", ".ttc"};
+            for(const char* ext : exts) {
+                auto candidate = path;
+                candidate += ext;
+                if(std::filesystem::exists(candidate)) {
+                    path = candidate;
+                    break;
+                }
+            }
+        }
+    }
+    if(std::filesystem::exists(path)) {
+        face = ft_.load(path);
+    }
+    if(!face && descr.family != "Arial") {
+        auto fallback = font_dir_ / "Arial.ttf";
+        if(std::filesystem::exists(fallback)) {
+            face = ft_.load(fallback);
+        }
+    }
+    if(!face) return 0;
+    FT_Set_Pixel_Sizes(face, 0, descr.size);
+    cairo_font_face_t* cf = cairo_ft_font_face_create_for_ft_face(face, 0);
+    cairo_matrix_t font_matrix, ctm;
+    cairo_matrix_init_scale(&font_matrix, descr.size, descr.size);
+    cairo_matrix_init_identity(&ctm);
+    cairo_font_options_t* opts = cairo_font_options_create();
+    cairo_scaled_font_t* sf = cairo_scaled_font_create(cf, &font_matrix, &ctm, opts);
+    cairo_font_options_destroy(opts);
+    cairo_font_face_destroy(cf);
+    if(fm) {
+        cairo_font_extents_t ext;
+        cairo_scaled_font_extents(sf, &ext);
+        fm->ascent = ext.ascent;
+        fm->descent = ext.descent;
+        fm->height = ext.height;
+    }
+    return reinterpret_cast<litehtml::uint_ptr>(sf);
+}
+
+void CairoContainer::delete_font(litehtml::uint_ptr hFont)
+{
+    if(hFont) {
+        cairo_scaled_font_destroy(reinterpret_cast<cairo_scaled_font_t*>(hFont));
+    }
+}
+
+int CairoContainer::text_width(const char* text, litehtml::uint_ptr hFont)
+{
+    cairo_scaled_font_t* sf = reinterpret_cast<cairo_scaled_font_t*>(hFont);
+    if(!sf) return strlen(text)*6;
+    cairo_text_extents_t ext;
+    cairo_scaled_font_text_extents(sf, text, &ext);
+    return (int)ext.x_advance;
+}
+
+void CairoContainer::draw_text(litehtml::uint_ptr, const char* text, litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos)
+{
+    cairo_scaled_font_t* sf = reinterpret_cast<cairo_scaled_font_t*>(hFont);
+    if(!sf) return;
+    cairo_t* cr = canvas_.cr();
+    cairo_set_scaled_font(cr, sf);
+    cairo_set_source_rgba(cr, color.red/255.0, color.green/255.0, color.blue/255.0, (255-color.alpha)/255.0);
+    cairo_move_to(cr, pos.x, pos.y);
+    cairo_show_text(cr, text);
+}
+
+int CairoContainer::pt_to_px(int pt) const
+{
+    return pt * 96 / 72;
+}
+
+int CairoContainer::get_default_font_size() const
+{
+    return 16;
+}
+
+const char* CairoContainer::get_default_font_name() const
+{
+    return "Arial";
+}
+
+void CairoContainer::draw_solid_fill(litehtml::uint_ptr, const litehtml::background_layer& layer, const litehtml::web_color& color)
+{
+    cairo_t* cr = canvas_.cr();
+    cairo_set_source_rgba(cr, color.red/255.0, color.green/255.0, color.blue/255.0, 1.0);
+    cairo_rectangle(cr, layer.clip_box.left(), layer.clip_box.top(), layer.clip_box.width, layer.clip_box.height);
+    cairo_fill(cr);
+}
+
+cairo_surface_t* CairoContainer::load_image_internal(const std::string& src, const std::string& base)
+{
+    auto it = image_cache_.find(src);
+    if(it != image_cache_.end()) return it->second.surf;
+    auto path = resolve_path(src, base);
+    if(path.empty() || !std::filesystem::exists(path)) return nullptr;
+    cairo_surface_t* surf = cairo_image_surface_create_from_png(path.string().c_str());
+    if(cairo_surface_status(surf) != CAIRO_STATUS_SUCCESS) {
+        cairo_surface_destroy(surf);
+        surf = nullptr;
+    }
+    if(surf) {
+        image_cache_[src] = {surf, cairo_image_surface_get_width(surf), cairo_image_surface_get_height(surf)};
+    }
+    return surf;
+}
+
+void CairoContainer::load_image(const char* src, const char* baseurl, bool)
+{
+    load_image_internal(src ? src : "", baseurl ? baseurl : "");
+}
+
+void CairoContainer::get_image_size(const char* src, const char* baseurl, litehtml::size& sz)
+{
+    auto surf = load_image_internal(src ? src : "", baseurl ? baseurl : "");
+    if(surf) {
+        sz.width = cairo_image_surface_get_width(surf);
+        sz.height = cairo_image_surface_get_height(surf);
+    } else {
+        sz.width = sz.height = 0;
+    }
+}
+
+void CairoContainer::draw_image(litehtml::uint_ptr, const litehtml::background_layer& layer, const std::string& url, const std::string& base_url)
+{
+    auto surf = load_image_internal(url, base_url);
+    if(!surf) return;
+    cairo_t* cr = canvas_.cr();
+    cairo_save(cr);
+    cairo_rectangle(cr, layer.clip_box.left(), layer.clip_box.top(), layer.clip_box.width, layer.clip_box.height);
+    cairo_clip(cr);
+    cairo_set_source_surface(cr, surf, layer.clip_box.left(), layer.clip_box.top());
+    cairo_paint(cr);
+    cairo_restore(cr);
+}
+
+void CairoContainer::transform_text(litehtml::string& text, litehtml::text_transform tt)
+{
+    if(tt == litehtml::text_transform_capitalize && !text.empty()) {
+        text[0] = toupper(text[0]);
+    } else if(tt == litehtml::text_transform_uppercase) {
+        for(auto& ch : text) ch = toupper(ch);
+    } else if(tt == litehtml::text_transform_lowercase) {
+        for(auto& ch : text) ch = tolower(ch);
+    }
+}
+
+void CairoContainer::get_viewport(litehtml::position& viewport) const
+{
+    viewport.x = 0;
+    viewport.y = 0;
+    viewport.width = cairo_image_surface_get_width(canvas_.surface());
+    viewport.height = cairo_image_surface_get_height(canvas_.surface());
+}
+
+void CairoContainer::get_media_features(litehtml::media_features& media) const
+{
+    media.type = litehtml::media_type_screen;
+    media.width = cairo_image_surface_get_width(canvas_.surface());
+    media.height = cairo_image_surface_get_height(canvas_.surface());
+    media.color = 8;
+}
+
+std::filesystem::path CairoContainer::resolve_path(const std::string& src, const std::string& base)
+{
+    std::filesystem::path b = base.empty() ? base_path_ : std::filesystem::path(base);
+    return html2img::resolve_asset(src, b, allow_remote_);
+}
+

--- a/php-8.4.10-devel-vs17-x64/src/cairo_container.hpp
+++ b/php-8.4.10-devel-vs17-x64/src/cairo_container.hpp
@@ -1,0 +1,69 @@
+#ifndef HTML2IMG_CAIRO_CONTAINER_HPP
+#define HTML2IMG_CAIRO_CONTAINER_HPP
+#define LITEHTML_STD_VARIANT 1
+#define LITEHTML_STD_OPTIONAL 1
+#define LITEHTML_STD_FILESYSTEM 1
+#include <litehtml.h>
+#include "cairo_canvas.hpp"
+#include "ft_cache.hpp"
+#include "path_utils.hpp"
+#include <filesystem>
+#include <unordered_map>
+
+class CairoContainer : public litehtml::document_container
+{
+public:
+    CairoContainer(CairoCanvas& canvas,
+                   const std::filesystem::path& base,
+                   const std::filesystem::path& font_dir,
+                   bool allow_remote);
+    void register_font(const std::string& family, const std::filesystem::path& path);
+    ~CairoContainer() override = default;
+
+    litehtml::uint_ptr create_font(const litehtml::font_description& descr, const litehtml::document* doc, litehtml::font_metrics* fm) override;
+    void delete_font(litehtml::uint_ptr hFont) override;
+    int text_width(const char* text, litehtml::uint_ptr hFont) override;
+    void draw_text(litehtml::uint_ptr hdc, const char* text, litehtml::uint_ptr hFont, litehtml::web_color color, const litehtml::position& pos) override;
+    int pt_to_px(int pt) const override;
+    int get_default_font_size() const override;
+    const char* get_default_font_name() const override;
+    void draw_list_marker(litehtml::uint_ptr, const litehtml::list_marker&) override {}
+    void load_image(const char* src, const char* baseurl, bool) override;
+    void get_image_size(const char* src, const char* baseurl, litehtml::size& sz) override;
+    void draw_image(litehtml::uint_ptr, const litehtml::background_layer& layer, const std::string& url, const std::string& base_url) override;
+    void draw_solid_fill(litehtml::uint_ptr, const litehtml::background_layer& layer, const litehtml::web_color& color) override;
+    void draw_linear_gradient(litehtml::uint_ptr, const litehtml::background_layer&, const litehtml::background_layer::linear_gradient&) override {}
+    void draw_radial_gradient(litehtml::uint_ptr, const litehtml::background_layer&, const litehtml::background_layer::radial_gradient&) override {}
+    void draw_conic_gradient(litehtml::uint_ptr, const litehtml::background_layer&, const litehtml::background_layer::conic_gradient&) override {}
+    void draw_borders(litehtml::uint_ptr, const litehtml::borders&, const litehtml::position&, bool) override {}
+
+    void set_caption(const char*) override {}
+    void set_base_url(const char* base_url) override { base_path_ = base_url ? base_url : ""; }
+    void link(const std::shared_ptr<litehtml::document>&, const litehtml::element::ptr&) override {}
+    void on_anchor_click(const char*, const litehtml::element::ptr&) override {}
+    void on_mouse_event(const litehtml::element::ptr&, litehtml::mouse_event) override {}
+    void set_cursor(const char*) override {}
+    void transform_text(litehtml::string& text, litehtml::text_transform tt) override;
+    void import_css(litehtml::string& text, const litehtml::string& url, litehtml::string& baseurl) override {}
+    void set_clip(const litehtml::position&, const litehtml::border_radiuses&) override {}
+    void del_clip() override {}
+    void get_viewport(litehtml::position& viewport) const override;
+    litehtml::element::ptr create_element(const char*, const litehtml::string_map&, const std::shared_ptr<litehtml::document>&) override { return nullptr; }
+    void get_media_features(litehtml::media_features& media) const override;
+    void get_language(litehtml::string& language, litehtml::string& culture) const override { language="en"; culture=""; }
+
+private:
+    CairoCanvas& canvas_;
+    std::filesystem::path base_path_;
+    std::filesystem::path font_dir_;
+    bool allow_remote_{};
+    FtCache ft_;
+    std::unordered_map<std::string, std::filesystem::path> font_map_;
+    struct ImageData { cairo_surface_t* surf{nullptr}; int w{}; int h{}; };
+    std::unordered_map<std::string, ImageData> image_cache_;
+
+    cairo_surface_t* load_image_internal(const std::string& src, const std::string& base);
+    std::filesystem::path resolve_path(const std::string& src, const std::string& base);
+};
+
+#endif

--- a/php-8.4.10-devel-vs17-x64/src/config.w32
+++ b/php-8.4.10-devel-vs17-x64/src/config.w32
@@ -7,7 +7,7 @@ if (PHP_HTML2IMG != "no") {
 
     /* 1) Core sources (contain MINIT/MINFO/…) */
     EXTENSION("html2img",
-        "php_html2img.cpp gd_canvas.cpp gd_container.cpp cache.cpp ft_cache.cpp path_utils.cpp");
+        "php_html2img.cpp cairo_canvas.cpp cairo_container.cpp cache.cpp ft_cache.cpp path_utils.cpp");
 
     /* 2) Extra C++ sources */
     ADD_SOURCES("html2img",
@@ -15,14 +15,14 @@ if (PHP_HTML2IMG != "no") {
 
     /* compiler flags */
     ADD_FLAG("CFLAGS_HTML2IMG",
-        "/std:c++17 /MT /EHsc /DWIN32 /DNDEBUG /DHTML2IMG_EXPORTS /D_UNICODE /DUNICODE /I ..\\thirdparty\\litehtml\\src\\gumbo\\include /I ..\\thirdparty\\litehtml\\src\\gumbo\\visualc\\include /I ..\\thirdparty\\litehtml\\src\\gumbo\\include\\gumbo /I F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\libgd-2.3.3\\src /I F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\thirdparty\\litehtml\\include /I F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\thirdparty\\litehtml\\include\\litehtml  /I F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\include\\freetype2");
+        "/std:c++17 /MT /EHsc /DWIN32 /DNDEBUG /DHTML2IMG_EXPORTS /D_UNICODE /DUNICODE /I ..\\thirdparty\\litehtml\\src\\gumbo\\include /I ..\\thirdparty\\litehtml\\src\\gumbo\\visualc\\include /I ..\\thirdparty\\litehtml\\src\\gumbo\\include\\gumbo /I ..\\thirdparty\\litehtml\\include /I ..\\thirdparty\\litehtml\\include\\litehtml  /I F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\include\\freetype2 /I F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\include\\cairo");
 
     /* if the four libs aren’t already found, keep this /libpath: */
     ADD_FLAG("LDFLAGS_HTML2IMG",
         '/libpath:"F:\\development\\steam\\emulator_bot\\php_html2img_ext\\php-8.4.10-devel-vs17-x64\\lib"');
 
     ADD_FLAG("LIBS_HTML2IMG",
-        "litehtml.lib libgd.lib freetype_a.lib libpng.lib libjpeg_a.lib libcrypto.lib ");
+        "litehtml.lib cairo.lib freetype_a.lib libpng.lib libjpeg_a.lib gif.lib libcrypto.lib ");
 
     AC_DEFINE("HAVE_HTML2IMG", 1, "Have html2img");
 }

--- a/php-8.4.10-devel-vs17-x64/src/php_html2img.cpp
+++ b/php-8.4.10-devel-vs17-x64/src/php_html2img.cpp
@@ -13,8 +13,8 @@
 #include <Zend/zend_execute.h>
 #include "path_utils.hpp"
 #include <chrono>
-#include "gd_canvas.hpp"
-#include "gd_container.hpp"
+#include "cairo_canvas.hpp"
+#include "cairo_container.hpp"
 #include "cache.hpp"
 #include "php_html2img_arginfo.h"   /* add after other #includes */
 
@@ -134,7 +134,7 @@ PHP_FUNCTION(html_css_to_image)
         RETURN_STRING(file.string().c_str());
     }
 
-    GDCanvas dummy(1,1,false);
+    CairoCanvas dummy(1,1,false);
     std::filesystem::path script_dir;
     {
         zend_string *exec = zend_get_executed_filename_ex();
@@ -149,7 +149,7 @@ PHP_FUNCTION(html_css_to_image)
         }
     }
     std::filesystem::path font_dir = html2img::resolve_asset(HTML2IMG_G(font_path), script_dir, false);
-    GDContainer cont(dummy, script_dir, font_dir, HTML2IMG_G(allow_remote));
+    CairoContainer cont(dummy, script_dir, font_dir, HTML2IMG_G(allow_remote));
     static const std::regex font_face_re("@font-face\\s*\\{[^}]*font-family:\\s*['\"]?([^;\"']+)['\"]?;[^}]*src:\\s*url\\(['\"]?([^\"')]+)['\"]?\)", std::regex::icase);
     for(std::sregex_iterator it(html_str.begin(), html_str.end(), font_face_re), end; it!=end; ++it) {
         std::string fam = (*it)[1].str();
@@ -162,8 +162,8 @@ PHP_FUNCTION(html_css_to_image)
     int w = doc->width();
     int h = doc->height();
 
-    GDCanvas canvas(w? w:1, h? h:1, false);
-    GDContainer cont2(canvas, script_dir, font_dir, HTML2IMG_G(allow_remote));
+    CairoCanvas canvas(w? w:1, h? h:1, false);
+    CairoContainer cont2(canvas, script_dir, font_dir, HTML2IMG_G(allow_remote));
     for(std::sregex_iterator it(html_str.begin(), html_str.end(), font_face_re), end; it!=end; ++it) {
         std::string fam = (*it)[1].str();
         std::filesystem::path p = html2img::from_file_uri((*it)[2].str());

--- a/tests/cairo_backend_test.cpp
+++ b/tests/cairo_backend_test.cpp
@@ -1,31 +1,31 @@
 #include <gtest/gtest.h>
-#include "../src/gd_canvas.hpp"
-#include "../src/gd_container.hpp"
+#include "../php-8.4.10-devel-vs17-x64/src/cairo_canvas.hpp"
+#include "../php-8.4.10-devel-vs17-x64/src/cairo_container.hpp"
 #include <litehtml.h>
 
 TEST(TransparentSurfaceTest, AlphaZeroWhenNoBackground)
 {
-    GDCanvas canvas(10,10,false);
-    GDContainer cont(canvas, ".", "./", false);
+    CairoCanvas canvas(10,10,false);
+    CairoContainer cont(canvas, ".", "./", false);
     auto doc = litehtml::document::createFromString("<div style=\"width:10px;height:10px\"></div>", &cont);
     doc->render(10);
     litehtml::position clip(0,0,10,10);
     doc->draw(0,0,0,&clip);
-    int c = gdImageGetTrueColorPixel(canvas.img(),0,0);
-    EXPECT_EQ(gdTrueColorGetAlpha(c), 127);
+    unsigned char* data = cairo_image_surface_get_data(canvas.surface());
+    EXPECT_EQ(data[3], 0);
 }
 
 TEST(OpaqueSurfaceTest, BackgroundFill)
 {
     const char* html = "<div style=\"background:#7B7F8D;width:10px;height:10px\"></div>";
-    GDCanvas canvas(10,10,true, gdTrueColor(0x7B,0x7F,0x8D));
-    GDContainer cont(canvas, ".", "./", false);
+    CairoCanvas canvas(10,10,true, 0x7B7F8D);
+    CairoContainer cont(canvas, ".", "./", false);
     auto doc = litehtml::document::createFromString(html, &cont);
     doc->render(10);
     litehtml::position clip(0,0,10,10);
     doc->draw(0,0,0,&clip);
-    int c = gdImageGetTrueColorPixel(canvas.img(),0,0);
-    EXPECT_EQ(gdTrueColorGetAlpha(c), 0);
+    unsigned char* data = cairo_image_surface_get_data(canvas.surface());
+    EXPECT_EQ(data[3], 255);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary
- implement Cairo-based canvas and container
- update PHP extension to use Cairo
- revise build scripts and CMake for Cairo, libpng, libjpeg and giflib
- update Windows config and tests

## Testing
- `cmake .. -DBUILD_TESTS=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: PHP extension not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6886a5842a988330b1db7918ed6b6d4d